### PR TITLE
Set ENABLE_BITCODE=NO to avoid errors when building using Xcode 7

### DIFF
--- a/Telegram-iOS-SDK.podspec
+++ b/Telegram-iOS-SDK.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '6.0'
   s.requires_arc = 'Pod/Classes/ARC/**/*'
-  s.xcconfig = { 'OTHER_LDFLAGS' => '-lstdc++ -ObjC' }
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-lstdc++ -ObjC', 'ENABLE_BITCODE' => 'NO' }
   s.source_files = 'Pod/Classes/**/*.{h,m,c,cpp,mm}'
   s.compiler_flags = '-Wall'
   s.resource_bundles = {


### PR DESCRIPTION
Hi @batkov 

I've tried to build a project of mine using your pod on Xcode 7 and I could see Xcode is now requesting for the flag ENABLE_BITCODE=NO when using static libraries.

If you fell this is a good improvement to your repo please accept this PR.

Best Regards